### PR TITLE
chore(ci): remove android cross stuff, bump ubuntu build to 20.04

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -21,46 +21,12 @@ passthrough = [
   "TARI_NETWORK_DIR",
 ]
 
-[target.x86_64-linux-android]
-image = "ghcr.io/cross-rs/x86_64-linux-android:edge"
-pre-build = [ """
-export DEBIAN_FRONTEND=noninteractive && \
-apt-get update && \
-apt-get --assume-yes --no-install-recommends install \
- curl unzip && \
-curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-x86_64.zip && \
-unzip -o protoc-26.1-linux-x86_64.zip -d /usr/ && \
-/usr/bin/protoc --version
-""" ]
-
-[target.x86_64-linux-android.env]
-passthrough = [
-  "CFLAGS=-DMDB_USE_ROBUST=0",
-]
-
-[target.aarch64-linux-android]
-image = "ghcr.io/cross-rs/aarch64-linux-android:edge"
-pre-build = [ """
-export DEBIAN_FRONTEND=noninteractive && \
-apt-get update && \
-apt-get --assume-yes --no-install-recommends install \
- curl unzip && \
-curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v26.1/protoc-26.1-linux-x86_64.zip && \
-unzip -o protoc-26.1-linux-x86_64.zip -d /usr/ && \
-/usr/bin/protoc --version
-""" ]
-
-[target.aarch64-linux-android.env]
-passthrough = [
-  "CFLAGS=-DMDB_USE_ROBUST=0",
-]
-
 # Currently needs cross-rs from git ```cargo install cross --git https://github.com/cross-rs/cross```
 [target.aarch64-unknown-linux-gnu]
-image.name = "ubuntu:18.04"
+image.name = "ubuntu:20.04"
 # targetting is needed for apple silicon
 image.toolchain = ["linux/arm64=aarch64-unknown-linux-gnu", "linux/amd64=x86_64-unknown-linux-gnu"]
-pre-build = "./scripts/cross_compile_ubuntu_18-pre-build.sh"
+pre-build = "./scripts/cross_compile_ubuntu_20-pre-build.sh"
 
 [target.aarch64-unknown-linux-gnu.env]
 passthrough = [
@@ -70,5 +36,10 @@ passthrough = [
 ]
 
 [target.x86_64-unknown-linux-gnu]
-image = "ubuntu:18.04"
-pre-build = "./scripts/cross_compile_ubuntu_18-pre-build.sh"
+image = "ubuntu:20.04"
+pre-build = "./scripts/cross_compile_ubuntu_20-pre-build.sh"
+
+[target.x86_64-unknown-linux-gnu.env]
+passthrough = [
+  "PKG_CONFIG_ALLOW_CROSS=true",
+]

--- a/scripts/cross_compile_ubuntu_20-pre-build.sh
+++ b/scripts/cross_compile_ubuntu_20-pre-build.sh
@@ -44,6 +44,12 @@ else
   exit 1
 fi
 
+DEBIAN_FRONTEND=${DEBIAN_FRONTEND:-noninteractive}
+# Hack of Note - workaround for apt asking for timezone info
+TimeZone=${TimeZone:-"Etc/GMT"}
+ln -snf /usr/share/zoneinfo/${TimeZone} /etc/localtime
+echo ${TimeZone} > /etc/timezone
+
 crossArch=${CROSS_DEB_ARCH}
 apt-get update
 
@@ -63,6 +69,7 @@ apt-get install --no-install-recommends --assume-yes \
   libsqlite3-0 \
   libreadline-dev \
   git \
+  make \
   cmake \
   dh-autoreconf \
   clang \
@@ -148,7 +155,6 @@ EoF
 
   # scripts/install_ubuntu_dependencies-cross_compile.sh x86-64
   apt-get --assume-yes install \
-    pkg-config-${targetPlatform}-linux-gnu \
     gcc-${targetPlatform}-linux-gnu \
     g++-${targetPlatform}-linux-gnu
 

--- a/scripts/install_ubuntu_dependencies.sh
+++ b/scripts/install_ubuntu_dependencies.sh
@@ -12,6 +12,7 @@ apt-get install --no-install-recommends --assume-yes \
   libsqlite3-0 \
   libreadline-dev \
   git \
+  make \
   cmake \
   dh-autoreconf \
   clang \


### PR DESCRIPTION
Description
Remove android cross stuff
Bump Ubuntu build target to 20.04 
Fix scripts for missing make deps

Motivation and Context
Improve Ubuntu build targets, should be able to build on Ubuntu 18.04 to 24.04

How Has This Been Tested?
Builds locally and in local fork
